### PR TITLE
Add simple calendar example

### DIFF
--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -1,0 +1,8 @@
+# Simple Calendar Example
+
+This example mirrors the calendar grid logic used in the main application.
+It reuses helper functions such as `removeAllOptionsForDay` and
+`formatDateWithoutTime` to toggle date selections.
+
+Open `SimpleCalendar.tsx` to see the simplified implementation based on the
+`month-calendar` component.

--- a/examples/simple/SimpleCalendar.tsx
+++ b/examples/simple/SimpleCalendar.tsx
@@ -1,0 +1,131 @@
+import React from "react";
+import dayjs from "dayjs";
+
+import { cn } from "../../packages/ui/src/lib/utils";
+import { useHeadlessDatePicker } from "../../apps/web/src/components/headless-date-picker";
+
+type DateOption = {
+  type: "date";
+  date: string;
+};
+
+type TimeOption = {
+  type: "timeSlot";
+  start: string;
+  duration: number;
+  end: string;
+};
+
+type DateTimeOption = DateOption | TimeOption;
+
+function formatDateWithoutTz(date: Date): string {
+  return dayjs(date).format("YYYY-MM-DDTHH:mm:ss");
+}
+
+function formatDateWithoutTime(date: Date): string {
+  return dayjs(date).format("YYYY-MM-DD");
+}
+
+function removeAllOptionsForDay(options: DateTimeOption[], date: Date) {
+  return options.filter((option) => {
+    return !dayjs(date).isSame(
+      option.type === "date" ? option.date : option.start,
+      "day",
+    );
+  });
+}
+
+/**
+ * Calendar example that mirrors the month-calendar component logic.
+ */
+export default function SimpleCalendar() {
+  const datepicker = useHeadlessDatePicker();
+  const [options, setOptions] = React.useState<DateTimeOption[]>([]);
+
+  const duration = 60;
+  const isTimedEvent = false;
+
+  const onChange = (opts: DateTimeOption[]) => setOptions(opts);
+  const onNavigate = (date: Date) => {
+    console.log("Navigate to", date.toISOString());
+  };
+
+  return (
+    <div className="grid grow grid-cols-7 rounded-md border bg-white shadow-sm">
+      {datepicker.days.map((day, i) => {
+        return (
+          <div
+            key={i}
+            className={cn("h-11", {
+              "border-r": (i + 1) % 7 !== 0,
+              "border-b": i < datepicker.days.length - 7,
+            })}
+          >
+            <button
+              type="button"
+              onClick={() => {
+                if (
+                  datepicker.selection.some((selectedDate) =>
+                    dayjs(selectedDate).isSame(day.date, "day"),
+                  )
+                ) {
+                  onChange(removeAllOptionsForDay(options, day.date));
+                } else {
+                  const selectedDate = dayjs(day.date)
+                    .set("hour", 12)
+                    .toDate();
+                  const newOption: DateTimeOption = !isTimedEvent
+                    ? {
+                        type: "date",
+                        date: formatDateWithoutTime(selectedDate),
+                      }
+                    : {
+                        type: "timeSlot",
+                        start: formatDateWithoutTz(selectedDate),
+                        duration,
+                        end: formatDateWithoutTz(
+                          dayjs(selectedDate)
+                            .add(duration, "minutes")
+                            .toDate(),
+                        ),
+                      };
+
+                  onChange([...options, newOption]);
+                  onNavigate(selectedDate);
+                }
+                if (day.outOfMonth) {
+                  if (i < 6) {
+                    datepicker.prev();
+                  } else {
+                    datepicker.next();
+                  }
+                }
+              }}
+              className={cn(
+                "group relative flex h-full w-full items-start justify-end rounded-none px-2.5 py-1.5 text-sm font-medium tracking-tight focus:z-10 focus:rounded",
+                {
+                  "bg-gray-100 text-gray-400": day.isPast,
+                  "text-rose-600": day.today && !day.selected,
+                  "bg-gray-50 text-gray-500":
+                    day.outOfMonth && !day.isPast,
+                  "text-primary-600": day.selected,
+                },
+              )}
+            >
+              <span
+                aria-hidden
+                className={cn(
+                  "absolute inset-1 -z-0 rounded-md border",
+                  day.selected
+                    ? "border-primary-300 group-hover:border-primary-400 border-dashed shadow-sm"
+                    : "border-dashed border-transparent group-hover:border-gray-400 group-active:bg-gray-200",
+                )}
+              ></span>
+              <span className="z-10">{day.day}</span>
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/examples/simple/SimpleCalendar.tsx
+++ b/examples/simple/SimpleCalendar.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import dayjs from "dayjs";
 
-import { cn } from "../../packages/ui/src/lib/utils";
-import { useHeadlessDatePicker } from "../../apps/web/src/components/headless-date-picker";
+import { cn } from "./utils";
+import { useHeadlessDatePicker } from "./headless-date-picker";
 
 type DateOption = {
   type: "date";
@@ -76,19 +76,19 @@ export default function SimpleCalendar() {
                     .toDate();
                   const newOption: DateTimeOption = !isTimedEvent
                     ? {
-                        type: "date",
-                        date: formatDateWithoutTime(selectedDate),
-                      }
+                      type: "date",
+                      date: formatDateWithoutTime(selectedDate),
+                    }
                     : {
-                        type: "timeSlot",
-                        start: formatDateWithoutTz(selectedDate),
-                        duration,
-                        end: formatDateWithoutTz(
-                          dayjs(selectedDate)
-                            .add(duration, "minutes")
-                            .toDate(),
-                        ),
-                      };
+                      type: "timeSlot",
+                      start: formatDateWithoutTz(selectedDate),
+                      duration,
+                      end: formatDateWithoutTz(
+                        dayjs(selectedDate)
+                          .add(duration, "minutes")
+                          .toDate(),
+                      ),
+                    };
 
                   onChange([...options, newOption]);
                   onNavigate(selectedDate);

--- a/examples/simple/headless-date-picker.tsx
+++ b/examples/simple/headless-date-picker.tsx
@@ -1,0 +1,112 @@
+import dayjs from "dayjs";
+import React from "react";
+
+interface DayProps {
+  date: Date;
+  day: string;
+  weekend: boolean;
+  outOfMonth: boolean;
+  today: boolean;
+  isPast: boolean;
+  selected: boolean;
+}
+
+interface HeadlessDatePickerOptions {
+  onSelectionChange?: (selection: Date[]) => void;
+  date?: Date;
+  selection?: Date[];
+  onNavigationChange?: (date: Date) => void;
+}
+
+const today = new Date();
+
+export const useHeadlessDatePicker = (
+  options?: HeadlessDatePickerOptions,
+): {
+  label: string;
+  next: () => void;
+  prev: () => void;
+  today: () => void;
+  daysOfWeek: string[];
+  days: DayProps[];
+  navigationDate: Date;
+  selection: Date[];
+  toggle: (date: Date) => void;
+} => {
+  const [localSelection, setSelection] = React.useState<Date[]>([]);
+  const selection = options?.selection ?? localSelection;
+  const [localNavigationDate, setNavigationDate] = React.useState(today);
+  const navigationDate = dayjs(options?.date ?? localNavigationDate);
+
+  const firstDayOfMonth = navigationDate.startOf("month");
+  const firstDayOfFirstWeek = firstDayOfMonth.startOf("week");
+
+  const currentMonth = navigationDate.get("month");
+
+  const days: DayProps[] = [];
+
+  const daysOfWeek: string[] = [];
+
+  for (let i = 0; i < 7; i++) {
+    daysOfWeek.push(firstDayOfFirstWeek.add(i, "days").format("dd"));
+  }
+
+  let reachedEnd = false;
+  let i = 0;
+  do {
+    const d = firstDayOfFirstWeek.add(i, "days");
+    days.push({
+      date: d.toDate(),
+      day: d.format("D"),
+      weekend: d.day() === 0 || d.day() === 6,
+      outOfMonth: d.month() !== currentMonth,
+      today: d.isSame(today, "day"),
+      selected: selection.some((selectedDate) => d.isSame(selectedDate, "day")),
+      isPast: d.isBefore(today, "day"),
+    });
+    i++;
+    reachedEnd =
+      i > 34 && i % 7 === 0 && d.add(1, "day").month() !== currentMonth;
+  } while (reachedEnd === false);
+
+  return {
+    navigationDate: navigationDate.toDate(),
+    label: navigationDate.format("MMMM YYYY"),
+    next: () => {
+      const newDate = navigationDate.add(1, "month").startOf("month").toDate();
+      if (!options?.date) {
+        setNavigationDate(newDate);
+      }
+      options?.onNavigationChange?.(newDate);
+    },
+    prev: () => {
+      const newDate = navigationDate.add(-1, "month").startOf("month").toDate();
+      if (!options?.date) {
+        setNavigationDate(newDate);
+      }
+      options?.onNavigationChange?.(newDate);
+    },
+    today: () => {
+      const newDate = today;
+      if (!options?.date) {
+        setNavigationDate(newDate);
+      }
+      options?.onNavigationChange?.(newDate);
+    },
+    days,
+    daysOfWeek,
+    selection: options?.selection ?? selection,
+    toggle: (date) => {
+      if (options?.selection) {
+        // ignore, selection is controlled externally
+        return;
+      }
+      const index = selection.indexOf(date);
+      if (index === -1) {
+        setSelection((s) => [...s, date]);
+      } else {
+        setSelection((s) => s.splice(index, 1));
+      }
+    },
+  };
+};

--- a/examples/simple/utils.ts
+++ b/examples/simple/utils.ts
@@ -1,0 +1,7 @@
+import type { ClassValue } from "clsx";
+import clsx from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## Summary
- add a simple example folder showing a stripped-down calendar
- expand the example to use the main calendar logic

## Testing
- `yarn lint` *(fails: could not download Yarn)*