### PR TITLE
Add calendar component using headless date picker

### DIFF
--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -1,0 +1,8 @@
+# Simple Calendar Example
+
+This example demonstrates a minimal version of the month calendar found in
+`apps/web`.
+Instead of dealing with date objects, it allows selecting numbers from an array
+for demonstration purposes.
+
+Open `SimpleCalendar.tsx` to see the implementation.

--- a/examples/simple/SimpleCalendar.tsx
+++ b/examples/simple/SimpleCalendar.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+/**
+ * Minimal calendar example that toggles numbers in an array.
+ */
+export default function SimpleCalendar() {
+  const days = Array.from({ length: 30 }, (_, i) => i + 1);
+  const [selected, setSelected] = React.useState<number[]>([]);
+
+  const toggle = (day: number) => {
+    setSelected(prev =>
+      prev.includes(day) ? prev.filter(d => d !== day) : [...prev, day]
+    );
+  };
+
+  return (
+    <div className="grid grid-cols-7 gap-1 w-64">
+      {days.map(day => (
+        <button
+          key={day}
+          onClick={() => toggle(day)}
+          className={`h-10 border rounded ${
+            selected.includes(day) ? 'bg-blue-100' : 'bg-white'
+          }`}
+        >
+          {day}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,5 @@
+# Simple Calendar
+
+This folder contains a minimal example that reuses the month-calendar logic.
+`SimpleCalendar.tsx` imports `useHeadlessDatePicker` and includes the same
+selection code found in the production `month-calendar` component.

--- a/src/SimpleCalendar.tsx
+++ b/src/SimpleCalendar.tsx
@@ -1,0 +1,106 @@
+import React from "react";
+import dayjs from "dayjs";
+
+import { cn } from "../packages/ui/src/lib/utils";
+import { useHeadlessDatePicker } from "../apps/web/src/components/headless-date-picker";
+import {
+  DateTimeOption,
+  removeAllOptionsForDay,
+  formatDateWithoutTime,
+  formatDateWithoutTz,
+} from "./utils";
+
+/**
+ * Simplified calendar that mirrors the production logic.
+ */
+export default function SimpleCalendar() {
+  const datepicker = useHeadlessDatePicker();
+  const [options, setOptions] = React.useState<DateTimeOption[]>([]);
+
+  const duration = 60;
+  const isTimedEvent = false;
+
+  const onChange = (opts: DateTimeOption[]) => setOptions(opts);
+  const onNavigate = (date: Date) => {
+    console.log("Navigate to", date.toISOString());
+  };
+
+  return (
+    <div className="grid grow grid-cols-7 rounded-md border bg-white shadow-sm">
+      {datepicker.days.map((day, i) => {
+        return (
+          <div
+            key={i}
+            className={cn("h-11", {
+              "border-r": (i + 1) % 7 !== 0,
+              "border-b": i < datepicker.days.length - 7,
+            })}
+          >
+            <button
+              type="button"
+              onClick={() => {
+                if (
+                  datepicker.selection.some((selectedDate) =>
+                    dayjs(selectedDate).isSame(day.date, "day"),
+                  )
+                ) {
+                  onChange(removeAllOptionsForDay(options, day.date));
+                } else {
+                  const selectedDate = dayjs(day.date)
+                    .set("hour", 12)
+                    .toDate();
+                  const newOption: DateTimeOption = !isTimedEvent
+                    ? {
+                        type: "date",
+                        date: formatDateWithoutTime(selectedDate),
+                      }
+                    : {
+                        type: "timeSlot",
+                        start: formatDateWithoutTz(selectedDate),
+                        duration,
+                        end: formatDateWithoutTz(
+                          dayjs(selectedDate)
+                            .add(duration, "minutes")
+                            .toDate(),
+                        ),
+                      };
+
+                  onChange([...options, newOption]);
+                  onNavigate(selectedDate);
+                }
+                if (day.outOfMonth) {
+                  if (i < 6) {
+                    datepicker.prev();
+                  } else {
+                    datepicker.next();
+                  }
+                }
+              }}
+              className={cn(
+                "group relative flex h-full w-full items-start justify-end rounded-none px-2.5 py-1.5 text-sm font-medium tracking-tight focus:z-10 focus:rounded",
+                {
+                  "bg-gray-100 text-gray-400": day.isPast,
+                  "text-rose-600": day.today && !day.selected,
+                  "bg-gray-50 text-gray-500":
+                    day.outOfMonth && !day.isPast,
+                  "text-primary-600": day.selected,
+                },
+              )}
+            >
+              <span
+                aria-hidden
+                className={cn(
+                  "absolute inset-1 -z-0 rounded-md border",
+                  day.selected
+                    ? "border-primary-300 group-hover:border-primary-400 border-dashed shadow-sm"
+                    : "border-dashed border-transparent group-hover:border-gray-400 group-active:bg-gray-200",
+                )}
+              ></span>
+              <span className="z-10">{day.day}</span>
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,35 @@
+import dayjs from "dayjs";
+
+export type DateOption = {
+  type: "date";
+  date: string;
+};
+
+export type TimeOption = {
+  type: "timeSlot";
+  start: string;
+  duration: number;
+  end: string;
+};
+
+export type DateTimeOption = DateOption | TimeOption;
+
+export function formatDateWithoutTz(date: Date): string {
+  return dayjs(date).format("YYYY-MM-DDTHH:mm:ss");
+}
+
+export function formatDateWithoutTime(date: Date): string {
+  return dayjs(date).format("YYYY-MM-DD");
+}
+
+export function removeAllOptionsForDay(
+  options: DateTimeOption[],
+  date: Date,
+) {
+  return options.filter((option) => {
+    return !dayjs(date).isSame(
+      option.type === "date" ? option.date : option.start,
+      "day",
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- add a small `src` folder with a simplified calendar that keeps the original month-calendar logic
- include helper functions in `src/utils.ts`
- document the example in `src/README.md`

## Testing
- `yarn lint` *(fails: could not download Yarn)*